### PR TITLE
fix: baseUrl 경로 수정

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   url: 'https://pig-cola.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: 'portfolio/disgusting-ux-ui/',
+  baseUrl: '/disgusting-ux-ui/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
`docusaurus.config.ts` 파일에서 `baseUrl` 경로를 수정하여 GitHub 페이지 배포에 적합하도록 변경함.